### PR TITLE
Update cdash templates for certificate configuration

### DIFF
--- a/charts/cdash/templates/cfm-key.yaml
+++ b/charts/cdash/templates/cfm-key.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.application.key }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -6,3 +7,4 @@ metadata:
 data:
   my-cert.key: |
     {{- .Values.application.key | nindent 4 }}
+{{- end }}

--- a/charts/cdash/templates/cfm-pem.yaml
+++ b/charts/cdash/templates/cfm-pem.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.application.pem }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -5,4 +6,5 @@ metadata:
   name: my-cert.pem
 data:
   my-cert.pem: |
-    {{- .Values.application.pem | nindent 4 }}
+    {{- .Values.application.pem | nindent 4 }}~
+{{- end }}

--- a/charts/cdash/templates/dpl-cdash.yaml
+++ b/charts/cdash/templates/dpl-cdash.yaml
@@ -24,8 +24,17 @@ spec:
               value: {{ .Values.application.env }}
             - name: ADMIN_INSTITUTION
               value: {{ .Values.application.institution | quote }}
+            {{- if .Values.application.password }}
             - name: ADMIN_PASSWORD
               value: {{ .Values.application.password }}
+            {{- end}}
+            {{- if .Values.application.password_secret }}
+            - name: ADMIN_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.application.password_secret }}
+                  key: password
+            {{- end}}
             - name: APP_DEBUG
               value: "true"
             - name: APP_URL
@@ -110,10 +119,10 @@ spec:
       {{- if .Values.application.tls }}
         - name: cdash-my-cert-key
           configMap:
-            name: my-cert.key
+            name: {{ .Values.application.key_secret | default "my-cert.key" }}
         - name: cdash-my-cert-pem
           configMap:
-            name: my-cert.pem
+            name: {{ .Values.application.pem_secret | default "my-cert.key" }}
       {{- end}}
         - name: cdashdata
           persistentVolumeClaim:

--- a/charts/cdash/templates/dpl-cdash.yaml
+++ b/charts/cdash/templates/dpl-cdash.yaml
@@ -72,8 +72,17 @@ spec:
               value: {{ .Values.ldap.basedn }}
             - name: LDAP_USERNAME
               value: {{ .Values.ldap.username }}
+            {{- if .Values.ldap.password  }}
             - name: LDAP_PASSWORD
-              value: {{ .Values.ldap.password | quote }}
+              value: {{ .Values.ldap.password  }}
+            {{- end}}
+            {{- if .Values.ldap.password_secret }}
+            - name: LDAP_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.ldap.password_secret }}
+                  key: ldap_password
+            {{- end}}
             - name: LDAP_LOGGING
               value: {{ .Values.ldap.logging | quote }}
             - name: LDAP_FILTERS_ON

--- a/charts/cdash/values.yaml
+++ b/charts/cdash/values.yaml
@@ -37,7 +37,9 @@ storageClassName: local-path
 application:
   institution: ""
   password: ""
+  password_secret: ""
   appkey: DV5SQLqXCbpnme4z2pKNujd6gFW9hrj5
+  appkey_secret: ""
   env: testing
   tls: true
   protocol: http
@@ -48,11 +50,13 @@ application:
     #   -----BEGIN CERTIFICATE-----
     #   ...
     #   -----END CERTIFICATE-----
+  pem_secret: ""
   key: ""
     # key: |
     #   -----BEGIN PRIVATE KEY-----
     #   ...
     #   -----END PRIVATE KEY-----
+  key_secret: ""
 
 worker: 
   connection: database
@@ -76,6 +80,7 @@ ldap:
   basedn:
   username:
   password:
+  password_secret:
   filters:
 
 resources: {}


### PR DESCRIPTION
This PR add the possibility to add secrets instead of the values for the following values:

- application.password -> application.password_secret
- application.appkey -> application.appkey_secret
- application.pem -> application.pem_secret
- application.key -> application.key_secret
- ldap.password -> ldap.password_secret

You can use one or the other, never both at the same time
