### PR TITLE
Improved secret handling

### DIFF
--- a/charts/cdash/Chart.yaml
+++ b/charts/cdash/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: cdash
 description: A Helm Chart for CDash
-version: 1.1.0
+version: 1.2.0
 icon: https://www.cdash.org/wp-content/uploads/2019/05/slider-cdash.png
 keywords:
   - cdash

--- a/charts/cdash/templates/dpl-cdash.yaml
+++ b/charts/cdash/templates/dpl-cdash.yaml
@@ -127,21 +127,21 @@ spec:
       volumes:
       {{- if .Values.application.tls }}
         - name: cdash-my-cert-key
-        {{- if .Values.application.key_secret }}
+          {{- if .Values.application.key_secret }}
           secret:
             secretName: {{ .Values.application.key_secret }}
-        {{- else}}
+          {{- else}}
           configMap:
             name: my-cert.key
-        {{- end}}
+          {{- end}}
         - name: cdash-my-cert-pem
-        {{- if .Values.application.pem_secret }}
+          {{- if .Values.application.pem_secret }}
           secret:
             secretName: {{ .Values.application.pem_secret }}
-        {{- else}}
+          {{- else}}
           configMap:
             name: my-cert.pem
-        {{- end}}
+          {{- end}}
       {{- end}}
         - name: cdashdata
           persistentVolumeClaim:

--- a/charts/cdash/templates/dpl-cdash.yaml
+++ b/charts/cdash/templates/dpl-cdash.yaml
@@ -81,7 +81,7 @@ spec:
               valueFrom:
                 secretKeyRef:
                   name: {{ .Values.ldap.password_secret }}
-                  key: ldap_password
+                  key: ldap-password
             {{- end}}
             - name: LDAP_LOGGING
               value: {{ .Values.ldap.logging | quote }}
@@ -127,11 +127,21 @@ spec:
       volumes:
       {{- if .Values.application.tls }}
         - name: cdash-my-cert-key
+        {{- if .Values.application.key_secret }}
+          secret:
+            secretName: {{ .Values.application.key_secret }}
+        {{- else}}
           configMap:
-            name: {{ .Values.application.key_secret | default "my-cert.key" }}
+            name: my-cert.key
+        {{- end}}
         - name: cdash-my-cert-pem
+        {{- if .Values.application.pem_secret }}
+          secret:
+            secretName: {{ .Values.application.pem_secret }}
+        {{- else}}
           configMap:
-            name: {{ .Values.application.pem_secret | default "my-cert.key" }}
+            name: my-cert.pem
+        {{- end}}
       {{- end}}
         - name: cdashdata
           persistentVolumeClaim:

--- a/charts/cdash/templates/dpl-worker.yaml
+++ b/charts/cdash/templates/dpl-worker.yaml
@@ -65,11 +65,23 @@ spec:
         - name: cdashdata
           persistentVolumeClaim:
             claimName: cdashdata
-        - name: cdash-my-cert-pem
-          configMap:
-            name: my-cert.pem
+        {{- if .Values.application.tls }}
         - name: cdash-my-cert-key
+          {{- if .Values.application.key_secret }}
+          secret:
+            secretName: {{ .Values.application.key_secret }}
+          {{- else}}
           configMap:
             name: my-cert.key
+          {{- end}}
+        - name: cdash-my-cert-pem
+          {{- if .Values.application.pem_secret }}
+          secret:
+            secretName: {{ .Values.application.pem_secret }}
+          {{- else}}
+          configMap:
+            name: my-cert.pem
+          {{- end}}
+        {{- end}}
 
 status: {}

--- a/index.yaml
+++ b/index.yaml
@@ -2,6 +2,23 @@ apiVersion: v1
 entries:
   cdash:
   - apiVersion: v2
+    created: "2024-08-22T12:14:49.45171842Z"
+    description: A Helm Chart for CDash
+    digest: 9104ada7a842e9c573dd7ec8ff725e8ac8375bfea497313ebf30fa5060f966a5
+    home: https://www.cdash.org
+    icon: https://www.cdash.org/wp-content/uploads/2019/05/slider-cdash.png
+    keywords:
+    - cdash
+    maintainers:
+    - email: pffmachado@gmail.com
+      name: Paulo Machado
+    name: cdash
+    sources:
+    - https://github.com/Kitware/CDash
+    urls:
+    - https://github.com/pffmachado/helm-charts/releases/download/cdash-1.2.0/cdash-1.2.0.tgz
+    version: 1.2.0
+  - apiVersion: v2
     created: "2024-08-22T12:01:42.513920132+01:00"
     description: A Helm Chart for CDash
     digest: f1a037b2a1d513b876a07bbecc92eb6f3bad39896cd9daf28000020aa34c7888
@@ -38,9 +55,9 @@ entries:
   flexlm:
   - apiVersion: v2
     appVersion: 1.16.0
-    created: "2024-08-22T12:01:42.672030458+01:00"
+    created: "2024-08-22T12:14:49.589849872Z"
     description: A Helm chart for FlexLM
-    digest: c66de7d57d2804fd751a7e582932fc0bf433f822f8971eff09d23e3ec2ba7ede
+    digest: d5c2c011c729590cb017378c9e9b44a2a9059719e8a9ba14f21f482fa7ae0432
     name: flexlm
     type: application
     urls:
@@ -196,4 +213,4 @@ entries:
     urls:
     - https://github.com/pffmachado/helm-charts/releases/download/flexlm-0.1.0/flexlm-0.1.0.tgz
     version: 0.1.0
-generated: "2024-08-22T12:01:42.671381274+01:00"
+generated: "2024-08-22T12:14:49.587791414Z"


### PR DESCRIPTION
Refactor cdash templates to handle secrets for key and pem files. If the value is specified, they are now stored as secrets. If the key value is provided, they continue to use configmap. This improves security and flexibility for certificate configuration.

fix the ldap variable _ to -

Bump cdash version to 1.2.0